### PR TITLE
Including SPDX license headers in generated files

### DIFF
--- a/ev-dev-tools/setup.cfg
+++ b/ev-dev-tools/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ev-dev-tools
-version = 0.0.1
+version = 0.0.2
 author = aw
 author_email = aw@pionix.de
 description = Utilities for developing with the everest framework

--- a/ev-dev-tools/src/ev_cli/ev.py
+++ b/ev-dev-tools/src/ev_cli/ev.py
@@ -43,7 +43,7 @@ validators = {}
 
 
 def setup_jinja_env():
-    env.globals['timestamp'] = datetime.utcnow
+    env.globals['timestamp'] = datetime.utcnow()
     # FIXME (aw): which repo to use? everest or everest-framework?
     env.globals['git'] = helpers.gather_git_info(everest_dir)
     env.filters['snake_case'] = helpers.snake_case

--- a/ev-dev-tools/src/ev_cli/templates/helper_macros.j2
+++ b/ev-dev-tools/src/ev_cli/templates/helper_macros.j2
@@ -62,6 +62,12 @@ handle_{{ cmd.name }}(
 {{ " "*indent }}{{ block.tag }}
 {%- endmacro %}
 
+{% macro print_spdx_line(license, year_tag=None) %}
+// SPDX-License-Identifier: {{ license }}
+// Copyright{% if year_tag %} {{ year_tag }}{% endif %} Pionix GmbH and Contributors to EVerest
+{%- endmacro %}
+
+
 {% macro print_template_info(version, title='DO NOT EDIT!', comment_sep='//') %}
 {{ comment_sep }}
 {{ comment_sep }} AUTO GENERATED - {{ title|upper }}

--- a/ev-dev-tools/src/ev_cli/templates/interface-Base.hpp.j2
+++ b/ev-dev-tools/src/ev_cli/templates/interface-Base.hpp.j2
@@ -1,8 +1,9 @@
-{% from "helper_macros.j2" import handle_cmd_signature, list_json_types, var_to_cpp, var_to_any, print_template_info %}
+{% from "helper_macros.j2" import handle_cmd_signature, list_json_types, var_to_cpp, var_to_any, print_template_info, print_spdx_line %}
+{{ print_spdx_line('Apache-2.0') }}
 #ifndef {{ info.hpp_guard }}
 #define {{ info.hpp_guard }}
 
-{{ print_template_info('0.0.1') }}
+{{ print_template_info('0.0.2') }}
 
 #include <framework/ModuleAdapter.hpp>
 

--- a/ev-dev-tools/src/ev_cli/templates/interface-Exports.hpp.j2
+++ b/ev-dev-tools/src/ev_cli/templates/interface-Exports.hpp.j2
@@ -1,8 +1,9 @@
-{% from "helper_macros.j2" import call_cmd_signature, var_to_any, var_to_cpp, print_template_info, cpp_type %}
+{% from "helper_macros.j2" import call_cmd_signature, var_to_any, var_to_cpp, print_template_info, cpp_type, print_spdx_line %}
+{{ print_spdx_line('Apache-2.0') }}
 #ifndef {{ info.hpp_guard }}
 #define {{ info.hpp_guard }}
 
-{{ print_template_info('0.0.1') }}
+{{ print_template_info('0.0.2') }}
 
 #include <framework/ModuleAdapter.hpp>
 

--- a/ev-dev-tools/src/ev_cli/templates/interface-Impl.cpp.j2
+++ b/ev-dev-tools/src/ev_cli/templates/interface-Impl.cpp.j2
@@ -1,4 +1,6 @@
-{% from "helper_macros.j2" import handle_cmd_signature %}
+{% from "helper_macros.j2" import handle_cmd_signature, print_spdx_line %}
+{{ print_spdx_line('Apache-2.0', "%s - %s" % (timestamp.year, timestamp.year)) }}
+
 #include "{{ info.class_name}}.hpp"
 
 namespace module {

--- a/ev-dev-tools/src/ev_cli/templates/interface-Impl.hpp.j2
+++ b/ev-dev-tools/src/ev_cli/templates/interface-Impl.hpp.j2
@@ -1,8 +1,9 @@
-{% from "helper_macros.j2" import handle_cmd_signature, print_template_info, insert_block, cpp_type %}
+{% from "helper_macros.j2" import handle_cmd_signature, print_template_info, insert_block, cpp_type, print_spdx_line %}
+{{ print_spdx_line('Apache-2.0') }}
 #ifndef {{ info.hpp_guard }}
 #define {{ info.hpp_guard }}
 
-{{ print_template_info('0.0.1', 'marked regions will be kept') }}
+{{ print_template_info('0.0.2', 'marked regions will be kept') }}
 
 #include <{{ info.base_class_header }}>
 

--- a/ev-dev-tools/src/ev_cli/templates/ld-ev.cpp.j2
+++ b/ev-dev-tools/src/ev_cli/templates/ld-ev.cpp.j2
@@ -1,5 +1,6 @@
-{% from "helper_macros.j2" import print_template_info, var_to_cpp %}
-{{ print_template_info('0.0.1') }}
+{% from "helper_macros.j2" import print_template_info, var_to_cpp, print_spdx_line %}
+{{ print_spdx_line('Apache-2.0') }}
+{{ print_template_info('0.0.2') }}
 
 #include "{{ info.ld_ev_header }}"
 

--- a/ev-dev-tools/src/ev_cli/templates/ld-ev.hpp.j2
+++ b/ev-dev-tools/src/ev_cli/templates/ld-ev.hpp.j2
@@ -1,8 +1,9 @@
-{% from "helper_macros.j2" import print_template_info %}
+{% from "helper_macros.j2" import print_template_info, print_spdx_line %}
+{{ print_spdx_line('Apache-2.0') }}
 #ifndef {{ info.hpp_guard }}
 #define {{ info.hpp_guard }}
 
-{{ print_template_info('0.0.1') }}
+{{ print_template_info('0.0.2') }}
 
 #include <framework/ModuleAdapter.hpp>
 #include <framework/everest.hpp>

--- a/ev-dev-tools/src/ev_cli/templates/module.cpp.j2
+++ b/ev-dev-tools/src/ev_cli/templates/module.cpp.j2
@@ -1,3 +1,5 @@
+{% from "helper_macros.j2" import print_spdx_line %}
+{{ print_spdx_line('Apache-2.0', "%s - %s" % (timestamp.year, timestamp.year)) }}
 #include "{{ info.module_header }}"
 
 namespace module {

--- a/ev-dev-tools/src/ev_cli/templates/module.hpp.j2
+++ b/ev-dev-tools/src/ev_cli/templates/module.hpp.j2
@@ -1,8 +1,9 @@
-{% from "helper_macros.j2" import print_template_info, insert_block, cpp_type %}
+{% from "helper_macros.j2" import print_template_info, insert_block, cpp_type, print_spdx_line %}
+{{ print_spdx_line('Apache-2.0') }}
 #ifndef {{ info.hpp_guard }}
 #define {{ info.hpp_guard }}
 
-{{ print_template_info('0.0.1', 'marked regions will be kept') }}
+{{ print_template_info('0.0.2', 'marked regions will be kept') }}
 
 #include "{{ info.ld_ev_header }}"
 


### PR DESCRIPTION
- the year tags are not included in auto-generated files, that might be
  overwritten again in future because the regexp and file handling would
  introduce quite some complexity, which might not be worth it
- only for implementation files, that will never be touched again by the
  generator (except forced overwrite), the current year is included and
  can be updated by the user

Signed-off-by: aw <aw@pionix.de>