### PR TITLE
Enable clang-format by default

### DIFF
--- a/ev-dev-tools/setup.cfg
+++ b/ev-dev-tools/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ev-dev-tools
-version = 0.0.2
+version = 0.0.3
 author = aw
 author_email = aw@pionix.de
 description = Utilities for developing with the everest framework

--- a/ev-dev-tools/src/ev_cli/ev.py
+++ b/ev-dev-tools/src/ev_cli/ev.py
@@ -415,7 +415,7 @@ def module_create(args):
             return
 
     for file_info in mod_files['core'] + mod_files['interfaces']:
-        if (args.clang_format_file):
+        if not args.disable_clang_format:
             helpers.clang_format(args.clang_format_file, file_info)
 
         helpers.write_content_to_file(file_info, create_strategy, args.diff)
@@ -441,7 +441,7 @@ def module_update(args):
             print(err)
             return
 
-    if (args.clang_format_file):
+    if not args.disable_clang_format:
         for file_info in mod_files['core'] + mod_files['interfaces']:
             helpers.clang_format(args.clang_format_file, file_info)
 
@@ -470,7 +470,7 @@ def interface_genhdr(args):
     for interface in interfaces:
         if_parts = generate_interface_headers(interface, all_interfaces)
 
-        if (args.clang_format_file):
+        if not args.disable_clang_format:
             helpers.clang_format(args.clang_format_file, if_parts['base'])
             helpers.clang_format(args.clang_format_file, if_parts['exports'])
 
@@ -495,8 +495,10 @@ def main():
                                help='everest directory containing the interface definitions (default: .)', default=str(Path.cwd()))
     common_parser.add_argument("--framework-dir", "-fd", type=str,
                                help='everest framework directory containing the schema definitions (default: ../everest-framework)', default=str(Path.cwd() / '../everest-framework'))
-    common_parser.add_argument("--clang-format-file", type=str, default="",
-                               help='If output should be formatted, set this to the path of the .clang-format file')
+    common_parser.add_argument("--clang-format-file", type=str, default=str(Path.cwd()),
+                               help='Path to the directory, containing the .clang-format file (default: .)')
+    common_parser.add_argument("--disable-clang-format", action='store_true', default=False,
+                               help="Set this flag to disable clang-format")
 
     subparsers = parser.add_subparsers(metavar='<command>', help='available commands', required=True)
     parser_mod = subparsers.add_parser('module', aliases=['mod'], help='module related actions')

--- a/ev-dev-tools/src/ev_cli/helpers.py
+++ b/ev-dev-tools/src/ev_cli/helpers.py
@@ -113,7 +113,7 @@ cpp_type_map = {
 }
 
 
-def clang_format(config_file, file_info):
+def clang_format(config_file_path, file_info):
     # check if we handle cpp and hpp files
     if not file_info['path'].suffix in ('.hpp', '.cpp'):
         return
@@ -122,9 +122,13 @@ def clang_format(config_file, file_info):
     if clang_format_path is None:
         raise RuntimeError('Could not find clang-format executable - needed when passing clang-format config file')
 
-    config_file_path = Path(config_file).parent.resolve()
+    config_file_path = Path(config_file_path)
     if not config_file_path.is_dir():
-        raise RuntimeError(f'Could not determine parent directory of supplied clang-format config file: {config_file}')
+        raise RuntimeError(f'Supplied directory for the clang-format file ({config_file_path}) does not exist')
+
+    if not (config_file_path / '.clang-format').exists():
+        raise RuntimeError(f'Supplied directory for the clang-format file '
+                           f'({config_file_path}) does not contain a .clang-format file')
 
     content = file_info['content']
 


### PR DESCRIPTION
- ev-cli will now use clang-format by default
- it will use the .clang-format file in the current working directory by
  default
- to explicitly disable clang-format, the --disable-clang-format flag
  was added

Signed-off-by: aw <aw@pionix.de>