### PR TITLE
Change var publish access from protected to public

### DIFF
--- a/ev-dev-tools/src/ev_cli/templates/interface-Base.hpp.j2
+++ b/ev-dev-tools/src/ev_cli/templates/interface-Base.hpp.j2
@@ -3,7 +3,7 @@
 #ifndef {{ info.hpp_guard }}
 #define {{ info.hpp_guard }}
 
-{{ print_template_info('1') }}
+{{ print_template_info('2') }}
 
 #include <framework/ModuleAdapter.hpp>
 

--- a/ev-dev-tools/src/ev_cli/templates/interface-Base.hpp.j2
+++ b/ev-dev-tools/src/ev_cli/templates/interface-Base.hpp.j2
@@ -11,7 +11,6 @@ class {{ info.class_name }} : public Everest::ImplementationBase {
 public:
     {{ info.class_name }}(Everest::ModuleAdapter* ev, const std::string& name) : Everest::ImplementationBase(), _ev(ev), _name(name) {};
 
-protected:
     {% if not vars %}
     // no variables defined for this interface
     {% else %}
@@ -21,6 +20,7 @@ protected:
     {% endfor %}
     {% endif %}
 
+protected:
     {% if not cmds %}
     // no commands defined for this interface
     {% else %}


### PR DESCRIPTION
This allows to call publish functions directly from module code. In the
current implementation this is only possible by using a sigslot signal
in the mod code and subscribing to that in the implementation code with
a publish wrapper which adds quite some unneccesary code.

Signed-off-by: Cornelius Claussen <cc@pionix.de>