### PR TITLE
STEVE with ARM64 architecture DOCKER fix

### DIFF
--- a/docker/steve/Dockerfile
+++ b/docker/steve/Dockerfile
@@ -4,10 +4,8 @@ ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
 
 WORKDIR /steve
 
-ENV DOCKERIZE_VERSION v0.6.1
-RUN wget --no-verbose https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
-    && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
-    && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+ENV DOCKERIZE_VERSION v0.19.0
+RUN curl -sfL https://github.com/powerman/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-`uname -s`-`uname -m` | install /dev/stdin /usr/local/bin/dockerize
 
 RUN wget -qO- https://github.com/RWTH-i5-IDSG/steve/archive/steve-3.4.5.tar.gz | tar xz --strip-components=1
 COPY main.properties src/main/resources/config/docker

--- a/docker/steve/Dockerfile
+++ b/docker/steve/Dockerfile
@@ -5,7 +5,7 @@ ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
 WORKDIR /steve
 
 ENV DOCKERIZE_VERSION v0.19.0
-RUN curl -sfL https://github.com/powerman/dockerize/releases/download/"$DOCKERIZE_VERSION"/dockerize-`uname -s`-`uname -m` | install /dev/stdin /usr/local/bin/dockerize
+RUN wget -O - https://github.com/powerman/dockerize/releases/download/"$DOCKERIZE_VERSION"/dockerize-`uname -s-uname -m` | install /dev/stdin /usr/local/bin/dockerize
 
 RUN wget -qO- https://github.com/RWTH-i5-IDSG/steve/archive/steve-3.4.5.tar.gz | tar xz --strip-components=1
 COPY main.properties src/main/resources/config/docker

--- a/docker/steve/Dockerfile
+++ b/docker/steve/Dockerfile
@@ -5,7 +5,7 @@ ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
 WORKDIR /steve
 
 ENV DOCKERIZE_VERSION v0.19.0
-RUN curl -sfL https://github.com/powerman/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-`uname -s`-`uname -m` | install /dev/stdin /usr/local/bin/dockerize
+RUN curl -sfL https://github.com/powerman/dockerize/releases/download/"$DOCKERIZE_VERSION"/dockerize-`uname -s`-`uname -m` | install /dev/stdin /usr/local/bin/dockerize
 
 RUN wget -qO- https://github.com/RWTH-i5-IDSG/steve/archive/steve-3.4.5.tar.gz | tar xz --strip-components=1
 COPY main.properties src/main/resources/config/docker


### PR DESCRIPTION
On ARM64 processors, as of right now, you cannot launch STEVE services using DOCKER. When ran using the normal java application it launches successfully. This is due to the fact that original Dockerize project has been left unmanaged. It does not provide a version compatible with ARM64 based processors as of right now and the project could be considered as discontinued for all I know. powerman/dockerize is another project picked up by the community from where the original left off and it seems to be a direct drop in replacement, at least for the basic commands such as dockerize -wait and it should be compatible with all/most architectures. I have a successful build running on an OrangePI4 LTS (aarm64) on which I installed Armbian OS.

You need to have curl installed for this modification to work. on the project github page ( https://github.com/powerman/dockerize ) they also left the wget command, I guess you should decide which is better to use.

wget -O - https://github.com/powerman/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-`uname -s`-`uname -m` | install /dev/stdin /usr/local/bin/dockerize