### PR TITLE
Support for returning array / std::vector in EVerest interfaces

### DIFF
--- a/ev-dev-tools/src/ev_cli/__init__.py
+++ b/ev-dev-tools/src/ev_cli/__init__.py
@@ -1,2 +1,2 @@
 """EVerest command line utility."""
-__version__ = "0.0.20"
+__version__ = "0.0.21"

--- a/ev-dev-tools/src/ev_cli/helpers.py
+++ b/ev-dev-tools/src/ev_cli/helpers.py
@@ -76,6 +76,8 @@ def create_dummy_result(json_type) -> str:
             return '"everest"'
         elif type == 'object':
             return '{}'
+        elif type == 'array':
+            return '{}'
         else:
             raise Exception(f'This json type "{type}" is not known or not implemented')
 

--- a/ev-dev-tools/src/ev_cli/templates/interface-Exports.hpp.j2
+++ b/ev-dev-tools/src/ev_cli/templates/interface-Exports.hpp.j2
@@ -81,6 +81,12 @@ public:
         {% elif 'object_type' in cmd.result %}
         json retval_json = result.value();
         {{ result_type(cmd.result) }} retval = retval_json;
+        {% elif 'array_type' in cmd.result %}
+        auto array = {{ var_to_cpp(cmd.result) }}(result.value());
+        {{ result_type(cmd.result) }} retval;
+        for (const auto& json_item : array) {
+            retval.push_back(json_item);
+        }
         {% else %}
         auto retval = {{ var_to_cpp(cmd.result) }}(result.value());
         {% endif %}

--- a/ev-dev-tools/src/ev_cli/templates/interface-Exports.hpp.j2
+++ b/ev-dev-tools/src/ev_cli/templates/interface-Exports.hpp.j2
@@ -82,11 +82,7 @@ public:
         json retval_json = result.value();
         {{ result_type(cmd.result) }} retval = retval_json;
         {% elif 'array_type' in cmd.result %}
-        auto array = {{ var_to_cpp(cmd.result) }}(result.value());
-        {{ result_type(cmd.result) }} retval;
-        for (const auto& json_item : array) {
-            retval.push_back(json_item);
-        }
+        {{ result_type(cmd.result) }} retval (result.value().begin(), result.value().end());
         {% else %}
         auto retval = {{ var_to_cpp(cmd.result) }}(result.value());
         {% endif %}


### PR DESCRIPTION
fixed generation of vector return type in interface and allow generation of default return value {} for vector