### PR TITLE
Extend templating to allow custom initializer lists

### DIFF
--- a/ev-dev-tools/src/ev_cli/ev.py
+++ b/ev-dev-tools/src/ev_cli/ev.py
@@ -273,6 +273,10 @@ def generate_module_files(rel_mod_dir, update_flag):
                 'id': '75ac1216-19eb-4182-a85c-820f1fc2c091',
                 'content': '// insert your custom include headers here'
             },
+            'initializer_list': {
+                'id': '7670c578-7b3a-4be3-8aa4-8a75976e3e56',
+                'content': "// replace this line with a single comma if you want to add custom stuff\n\n// insert your custom stuff to the initializer list here"
+            },
             'public_defs': {
                 'id': '8ea32d28-373f-4c90-ae5e-b4fcc74e2a61',
                 'content': '// insert your public definitions here'
@@ -300,6 +304,10 @@ def generate_module_files(rel_mod_dir, update_flag):
             'add_headers': {
                 'id': '4bf81b14-a215-475c-a1d3-0a484ae48918',
                 'content': '// insert your custom include headers here'
+            },
+            'initializer_list': {
+                'id': '2d974162-d3a8-46d3-915d-4d6964a7a6d2',
+                'content': "// replace this line with a single comma if you want to add custom stuff\n\n// insert your custom stuff to the initializer list here"
             },
             'public_defs': {
                 'id': '1fce4c5e-0ab8-41bb-90f7-14277703d2ac',

--- a/ev-dev-tools/src/ev_cli/templates/interface-Impl.hpp.j2
+++ b/ev-dev-tools/src/ev_cli/templates/interface-Impl.hpp.j2
@@ -3,7 +3,7 @@
 #ifndef {{ info.hpp_guard }}
 #define {{ info.hpp_guard }}
 
-{{ print_template_info('3', 'marked regions will be kept') }}
+{{ print_template_info('4', 'marked regions will be kept') }}
 
 #include <{{ info.base_class_header }}>
 
@@ -27,6 +27,7 @@ public:
         {{ info.class_parent }}(ev, "{{ info.interface_implementation_id }}"),
         mod(mod),
         config(config)
+        {{ insert_block(info.blocks.initializer_list, indent=8) }}
     {};
 
     {{ insert_block(info.blocks.public_defs, indent=4) }}

--- a/ev-dev-tools/src/ev_cli/templates/module.hpp.j2
+++ b/ev-dev-tools/src/ev_cli/templates/module.hpp.j2
@@ -3,7 +3,7 @@
 #ifndef {{ info.hpp_guard }}
 #define {{ info.hpp_guard }}
 
-{{ print_template_info('2', 'marked regions will be kept') }}
+{{ print_template_info('3', 'marked regions will be kept') }}
 
 #include "{{ info.ld_ev_header }}"
 
@@ -68,6 +68,7 @@ public:
         r_{{ requirement.id }}(std::move(r_{{ requirement.id }})),
         {% endfor %}
         config(config)
+        {{ insert_block(info.blocks.initializer_list, indent=8) }}
     {};
 
     {% if info.enable_external_mqtt %}


### PR DESCRIPTION
Sometimes it is desirable to add members to the classes which would require to extend the initializer lists.
At the moment, this cannot be done since no marked region exists which will be migrated when updating the module.

So lets add such a region. Nitpick is, that I did not find a nice way to handle the comma after the pre-generated list. So this is left to the module author to take care - at least we can give a hint in the description.