### PR TITLE
make evse security more flexible

### DIFF
--- a/everest-testing/src/everest/testing/core_utils/probe_module.py
+++ b/everest-testing/src/everest/testing/core_utils/probe_module.py
@@ -43,7 +43,7 @@ class ProbeModule:
         except Exception as e:
             logging.info(f"Exception in calling {connection_id}.{command_name}: {type(e)}: {e}")
 
-    def implement_command(self, implementation_id: str, command_name: str, handler: Callable[[dict], dict]):
+    def implement_command(self, implementation_id: str, command_name: str, handler: Callable[[dict], Any]):
         """
         Set up an implementation for a command.
         - implementation_id: the id of the implementation, as used by other modules requiring it in the runtime config
@@ -62,7 +62,7 @@ class ProbeModule:
         """
         self._mod.implement_command(implementation_id, command_name, handler)
 
-    def publish_variable(self, implementation_id: str, variable_name: str, value: dict | str):
+    def publish_variable(self, implementation_id: str, variable_name: str, value: Any):
         """
         Publish a variable from an interface the probe module implements.
         - implementation_id: the id of the implementation, as used by other modules requiring it in the runtime config


### PR DESCRIPTION
Makes the configuration of a evse security module more flexible by:
- allowing to only adapt paths according to the temporary directroy, but keeping the original configuration (i.e. relative paths)
- copy always the full certificate directory


Further minor changes:
- everest core can now use the pytest tmp path
- everest core refactorings (make more variables protected)
- probe module type adjustments