### PR TITLE
update `mariadb`-version to fix SteVe schema-migration failure; update SteVe to latest version

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - ./mosquitto/mosquitto.conf:/mosquitto/config/mosquitto.conf
 
   ocpp-db:
-    image: mariadb:10.4.30
+    image: mariadb:10.4.30 # pinned to patch-version because https://github.com/steve-community/steve/pull/1213
     volumes:
       - ocpp-db-data:/var/lib/mysql
     ports:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - ./mosquitto/mosquitto.conf:/mosquitto/config/mosquitto.conf
 
   ocpp-db:
-    image: mariadb:10.4
+    image: mariadb:10.4.30
     volumes:
       - ocpp-db-data:/var/lib/mysql
     ports:

--- a/docker/steve/Dockerfile
+++ b/docker/steve/Dockerfile
@@ -9,7 +9,7 @@ RUN wget --no-verbose https://github.com/jwilder/dockerize/releases/download/$DO
     && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
     && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
 
-RUN wget -qO- https://github.com/RWTH-i5-IDSG/steve/archive/steve-3.6.0.tar.gz | tar xz --strip-components=1
+RUN wget -qO- https://github.com/steve-community/steve/archive/steve-3.6.0.tar.gz | tar xz --strip-components=1
 COPY main.properties src/main/resources/config/docker
 COPY init.sh .
 COPY keystore.jks .

--- a/docker/steve/Dockerfile
+++ b/docker/steve/Dockerfile
@@ -9,7 +9,7 @@ RUN wget --no-verbose https://github.com/jwilder/dockerize/releases/download/$DO
     && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
     && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
 
-RUN wget -qO- https://github.com/RWTH-i5-IDSG/steve/archive/steve-3.4.5.tar.gz | tar xz --strip-components=1
+RUN wget -qO- https://github.com/RWTH-i5-IDSG/steve/archive/steve-3.6.0.tar.gz | tar xz --strip-components=1
 COPY main.properties src/main/resources/config/docker
 COPY init.sh .
 COPY keystore.jks .


### PR DESCRIPTION
Starting up a `steve`-container and `mariadb`  with a new, clean volume `ocpp-db-data` results in this error:

> [ERROR] Migration of schema `ocpp-db` to version "0.7.7 - update" failed! Please restore backups and roll back database and code!

<details><summary>Details</summary>
<p>

> [ERROR] Migration of schema `ocpp-db` to version "0.7.7 - update" failed! Please restore backups and roll back database and code!
> [INFO] ------------------------------------------------------------------------
> [INFO] BUILD FAILURE
> [INFO] ------------------------------------------------------------------------
> [INFO] Total time:  18.849 s
> [INFO] Finished at: 2023-11-02T12:59:23Z
> [INFO] ------------------------------------------------------------------------
> [ERROR] Failed to execute goal org.flywaydb:flyway-maven-plugin:7.9.1:migrate (default) on project steve: org.flywaydb.core.internal.command.DbMigrate$FlywayMigrateException: 
> [ERROR] Migration V0_7_7__update.sql failed
> [ERROR] -----------------------------------
> [ERROR] SQL State  : HY000
> [ERROR] Error Code : 1833
> [ERROR] Message    : Cannot change column 'chargeBoxId': used in a foreign key constraint 'ocpp@002ddb/FK_chargeBoxId_c' of table 'ocpp@002ddb/connector'
> [ERROR] Location   : /steve/src/main/resources/db/migration/V0_7_7__update.sql (/steve/src/main/resources/db/migration/V0_7_7__update.sql)

</p>
</details> 

The issue is reported upstream
- https://github.com/steve-community/steve/issues/1233

Version-pinning is done in
- https://github.com/steve-community/steve/pull/1213

I've also took the chance to update SteVe itself. Runs on my side.