### PR TITLE
Add explicit CSMS TLS marker

### DIFF
--- a/everest-testing/README.md
+++ b/everest-testing/README.md
@@ -66,7 +66,7 @@ An important function that you will frequently use when writing test cases is th
 - **ocpp_version**: Can be "ocpp1.6" or "ocpp2.0.1" and is used to setup EVerest and the central system for the specific OCPP version
 - **ocpp_config**: Specification of the .json OCPP config file. Used in `ocpp_config` fixture and used as template configuration (if not specified, the OCPP config as specified in the EVerest configuration is used) 
 - **inject_csms_mock**: (currently only OCPP 2.0.1) If set, the `central_system_v201` will wrap any csms handler method into an unittest mock. In particular, this allows changing the CSMS behavior even after the chargepoint is started by setting side effects of the mock. See `everest.testing.ocpp_utils.charge_point_v201.inject_csms_v201_mock` docstring for an example.
-
+- **csms_tls**: Enable/disable TLS for the CSMS websocket server. If given without arguments, enables TLS. First argument can be `False` to explicitly disable TLS. Further optional keyword arguments  `certificate`, `private_key`,`passphrase` allow to overwrite SSL context options.
 
 ## Add a conftest.py
 

--- a/everest-testing/src/everest/testing/ocpp_utils/charge_point_utils.py
+++ b/everest-testing/src/everest/testing/ocpp_utils/charge_point_utils.py
@@ -53,6 +53,7 @@ class FirmwareInfo:
 
 @dataclass
 class OcppTestConfiguration:
+    csms_tls_enabled = False
     csms_port: str = 9000
     csms_host: str = "127.0.0.1"
     charge_point_info: ChargePointInfo = ChargePointInfo()


### PR DESCRIPTION
Adds an explicit marker to enable CSMS TLS and potentially overwrite TLS settings.
- required to fix OCPP OCTT tests 74 & 75 (old "param" solution was broken; likely due to the change of fixtures)
- the ability to overwrite test-config settings via marker will be useful in OCPP 2.0.1 testing
