### PR TITLE
fix: Probe module waits for ready signal in another thread to avoid hangs

### DIFF
--- a/everest-testing/src/everest/testing/core_utils/probe_module.py
+++ b/everest-testing/src/everest/testing/core_utils/probe_module.py
@@ -116,4 +116,4 @@ class ProbeModule:
         if not self._started:
             raise RuntimeError("Called wait_to_be_ready(), but probe module has not been started yet! "
                                "Please use start() to start the module first.")
-        await asyncio.wait_for(asyncio.to_thread(lambda: self._ready_event.wait()), timeout)
+        await asyncio.wait_for(asyncio.to_thread(self._ready_event.wait), timeout)

--- a/everest-testing/src/everest/testing/core_utils/probe_module.py
+++ b/everest-testing/src/everest/testing/core_utils/probe_module.py
@@ -116,4 +116,4 @@ class ProbeModule:
         if not self._started:
             raise RuntimeError("Called wait_to_be_ready(), but probe module has not been started yet! "
                                "Please use start() to start the module first.")
-        await asyncio.wait_for(self._ready_event.wait(), timeout)
+        await asyncio.wait_for(asyncio.to_thread(lambda: self._ready_event.wait()), timeout)


### PR DESCRIPTION
NOTE: This may not be a full fix, as asyncio objects technically aren't thread-safe, but it works well enough for now.