### PR TITLE
Fix typo in Dockerfile

### DIFF
--- a/docker/everest-docker-image/Dockerfile
+++ b/docker/everest-docker-image/Dockerfile
@@ -92,7 +92,7 @@ RUN apt-get update \
     libboost-system1.74.0 \
     libssl1.1 \
     libcurl4 \
-    libcap \
+    libcap2 \
     less \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
install libcap2 instead of libcap