### PR TITLE
Bazel: Move formatting tests to the root

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -38,5 +38,8 @@ buildifier_test(
         "BUILD.bazel",
         "WORKSPACE.bazel",
         "requirements.bzl",
+        "@everest-utils//ev-dev-tools:BUILD.bazel",
+        "@everest-utils//everest-testing:BUILD.bazel",
+        "@everest-utils//third-party/bazel:BUILD.bazel",
     ],
 )

--- a/ev-dev-tools/BUILD.bazel
+++ b/ev-dev-tools/BUILD.bazel
@@ -1,10 +1,8 @@
-load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier_test")
 load("@everest-utils//:requirements.bzl", "requirement")
 load("@rules_python//python:defs.bzl", "py_binary", "py_library")
 
-buildifier_test(
-    name = "buildifier_test",
-    srcs = ["BUILD.bazel"],
+exports_files(
+    ["BUILD.bazel"],
 )
 
 py_library(

--- a/everest-testing/BUILD.bazel
+++ b/everest-testing/BUILD.bazel
@@ -1,10 +1,8 @@
-load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier_test")
 load("@everest-utils//:requirements.bzl", "requirement")
 load("@rules_python//python:defs.bzl", "py_library")
 
-buildifier_test(
-    name = "buildifier_test",
-    srcs = ["BUILD.bazel"],
+exports_files(
+    ["BUILD.bazel"],
 )
 
 py_library(

--- a/third-party/bazel/BUILD.bazel
+++ b/third-party/bazel/BUILD.bazel
@@ -1,8 +1,5 @@
-load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier_test")
-
-buildifier_test(
-    name = "buildifier_test",
-    srcs = ["BUILD.bazel"] + glob([
+exports_files(
+    ["BUILD.bazel"] + glob([
         "**/*.bzl",
     ]),
 )


### PR DESCRIPTION
Here we move the formatting checks to the root build file, that is not supposed to be consumed by the downstream repositories.

This way they don't need to add all the dependencies for formatting in the downstream repositories.