### PR TITLE
change static const to inline to avoid warnings and potentially decre…

### DIFF
--- a/ev-dev-tools/src/ev_cli/templates/types.hpp.j2
+++ b/ev-dev-tools/src/ev_cli/templates/types.hpp.j2
@@ -40,7 +40,7 @@ enum class {{ enum.enum_type}}
 
 /// \brief Converts the given {{ enum.enum_type }} \p e to human readable string
 /// \returns a string representation of the {{ enum.enum_type }}
-static const std::string {{ enum.enum_type | snake_case }}_to_string({{ enum.enum_type }} e) {
+inline std::string {{ enum.enum_type | snake_case }}_to_string({{ enum.enum_type }} e) {
     switch (e) {
         {% for e in enum.enum %}
         case {{ enum.enum_type }}::{{ e }}: return "{{e}}";
@@ -52,7 +52,7 @@ static const std::string {{ enum.enum_type | snake_case }}_to_string({{ enum.enu
 
 /// \brief Converts the given std::string \p s to {{ enum.enum_type }}
 /// \returns a {{ enum.enum_type }} from a string representation
-static const {{ enum.enum_type }} string_to_{{ enum.enum_type | snake_case }}(const std::string& s) {
+inline {{ enum.enum_type }} string_to_{{ enum.enum_type | snake_case }}(const std::string& s) {
     {% for e in enum.enum %}
     if(s == "{{e}}") {
         return {{ enum.enum_type }}::{{ e }};


### PR DESCRIPTION
…ase code size

The static keyword in this context means that it is guaranteed to stay in the compilation unit of each compiled source file that includes it, whereas inline represents a single implementation.

Declaring return values const triggers the warning ignored-qualifiers (which is in -Wextra in gcc), because by value this const qualifier will be discarded. So it's not really doing anything except trigger warnings.