### PR TITLE
Refactor error framework C++ interface 

### DIFF
--- a/ev-dev-tools/src/ev_cli/__init__.py
+++ b/ev-dev-tools/src/ev_cli/__init__.py
@@ -1,2 +1,2 @@
 """EVerest command line utility."""
-__version__ = '0.0.24'
+__version__ = '0.1.0'

--- a/ev-dev-tools/src/ev_cli/templates/interface-Base.hpp.j2
+++ b/ev-dev-tools/src/ev_cli/templates/interface-Base.hpp.j2
@@ -19,10 +19,28 @@ public:
     {{ info.class_name }}(Everest::ModuleAdapter* ev, const std::string& name)
         : Everest::ImplementationBase(),
         _ev(ev),
-        _name(name),
-        error_manager(ev->get_error_manager_impl(name)),
-        error_state_monitor(ev->get_error_state_monitor_impl(name)),
-        error_factory(ev->get_error_factory(name)) {}
+        _name(name) {
+        if (ev == nullptr) {
+            EVLOG_error << "ev is nullptr, please check the initialization of the module";
+            error_manager = nullptr;
+            error_state_monitor = nullptr;
+            error_factory = nullptr;
+            EVLOG_error << "error_manager, error_state_monitor and error_factory are nullptr";
+        } else {
+            error_manager = ev->get_error_manager_impl(name);
+            if (error_manager == nullptr) {
+                EVLOG_error << "error_manager is nullptr";
+            }
+            error_state_monitor = ev->get_error_state_monitor_impl(name);
+            if (error_state_monitor == nullptr) {
+                EVLOG_error << "error_state_monitor is nullptr";
+            }
+            error_factory = ev->get_error_factory(name);
+            if (error_factory == nullptr) {
+                EVLOG_error << "error_factory is nullptr";
+            }
+        }
+    }
 
     {% if not vars %}
     // no variables defined for this interface

--- a/ev-dev-tools/src/ev_cli/templates/interface-Base.hpp.j2
+++ b/ev-dev-tools/src/ev_cli/templates/interface-Base.hpp.j2
@@ -8,12 +8,21 @@
 #include <framework/ModuleAdapter.hpp>
 #include <utils/types.hpp>
 #include <utils/error.hpp>
+#include <utils/error/error_state_monitor.hpp>
+#include <utils/error/error_manager_impl.hpp>
+#include <utils/error/error_factory.hpp>
 
 #include "Types.hpp"
 
 class {{ info.class_name }} : public Everest::ImplementationBase {
 public:
-    {{ info.class_name }}(Everest::ModuleAdapter* ev, const std::string& name) : Everest::ImplementationBase(), _ev(ev), _name(name) {};
+    {{ info.class_name }}(Everest::ModuleAdapter* ev, const std::string& name)
+        : Everest::ImplementationBase(),
+        _ev(ev),
+        _name(name),
+        error_manager(ev->get_error_manager_impl(name)),
+        error_state_monitor(ev->get_error_state_monitor_impl(name)),
+        error_factory(ev->get_error_factory(name)) {}
 
     {% if not vars %}
     // no variables defined for this interface
@@ -43,33 +52,24 @@ public:
     {% endfor %}
     {% endif %}
 
-    {% if not errors %}
-    // no errors defined for this interface
-    {% else %}
-    // raise functions for errors
-    {% for error in errors %}
-    Everest::error::ErrorHandle raise_{{ error.namespace }}_{{ error.name }}(const std::string& message, const Everest::error::Severity& severity=Everest::error::Severity::Low) {
-        return _ev->raise_error(
-            _name,
-            "{{ error.namespace }}/{{ error.name }}",
-            message,
-            severity
-        );
+    void raise_error(const Everest::error::Error& error) {
+        error_manager->raise_error(error);
     }
-    {% endfor %}
-    // request clear functions for errors
-    {% for error in errors %}
-    void request_clear_all_{{ error.namespace }}_{{ error.name }}() {
-        _ev->request_clear_all_errors_of_type_of_module(_name, "{{ error.namespace }}/{{ error.name }}");
+    
+    void clear_error(const Everest::error::ErrorType& type, const bool clear_all = false) {
+        error_manager->clear_error(type, clear_all);
     }
-    {% endfor %}
-    void request_clear_error(const Everest::error::ErrorHandle& handle) {
-        _ev->request_clear_error_uuid(_name, handle);
+
+    void clear_error(const Everest::error::ErrorType& type, const Everest::error::ErrorSubType& sub_type) {
+        error_manager->clear_error(type, sub_type);
     }
-    void request_clear_all_errors() {
-        _ev->request_clear_all_errors_of_module(_name);
+
+    void clear_all_errors_of_impl() {
+        error_manager->clear_all_errors();
     }
-    {% endif %}
+
+    std::shared_ptr<Everest::error::ErrorStateMonitor> error_state_monitor;
+    std::shared_ptr<Everest::error::ErrorFactory> error_factory;
 
 protected:
     {% if not cmds %}
@@ -84,6 +84,7 @@ protected:
 private:
     Everest::ModuleAdapter* const _ev;
     const std::string _name;
+    std::shared_ptr<Everest::error::ErrorManagerImpl> error_manager;
 
     // helper function for getting all commands
     void _gather_cmds(std::vector<Everest::cmd>& cmds) override {

--- a/ev-dev-tools/src/ev_cli/templates/interface-Exports.hpp.j2
+++ b/ev-dev-tools/src/ev_cli/templates/interface-Exports.hpp.j2
@@ -18,9 +18,23 @@ public:
     {{ info.class_name }}(Everest::ModuleAdapter* adapter, Requirement req, const std::string& module_id)
         : module_id(module_id),
         _adapter(adapter),
-        _req(req),
-        error_manager(adapter->get_error_manager_req(req)),
-        error_state_monitor(adapter->get_error_state_monitor_req(req)) {}
+        _req(req) {
+        if (adapter == nullptr) {
+            EVLOG_error << "adapter is nullptr, please check the initialization of the module";
+            error_manager = nullptr;
+            error_state_monitor = nullptr;
+            EVLOG_error << "error_manager and error_state_monitor are nullptr";
+        } else {
+            error_manager = adapter->get_error_manager_req(req);
+            if (error_manager == nullptr) {
+                EVLOG_error << "error_manager is nullptr";
+            }
+            error_state_monitor = adapter->get_error_state_monitor_req(req);
+            if (error_state_monitor == nullptr) {
+                EVLOG_error << "error_state_monitor is nullptr";
+            }
+        }
+    }
 
     const std::string module_id;
 

--- a/ev-dev-tools/src/ev_cli/templates/interface-Exports.hpp.j2
+++ b/ev-dev-tools/src/ev_cli/templates/interface-Exports.hpp.j2
@@ -6,12 +6,21 @@
 {{ print_template_info('3') }}
 
 #include <framework/ModuleAdapter.hpp>
+#include <utils/types.hpp>
+#include <utils/error.hpp>
+#include <utils/error/error_state_monitor.hpp>
+#include <utils/error/error_manager_req.hpp>
 
 #include "Types.hpp"
 
 class {{ info.class_name }} {
 public:
-    {{ info.class_name }}(Everest::ModuleAdapter* adapter, Requirement req, const std::string& module_id) : module_id(module_id), _adapter(adapter), _req(req){};
+    {{ info.class_name }}(Everest::ModuleAdapter* adapter, Requirement req, const std::string& module_id)
+        : module_id(module_id),
+        _adapter(adapter),
+        _req(req),
+        error_manager(adapter->get_error_manager_req(req)),
+        error_state_monitor(adapter->get_error_state_monitor_req(req)) {}
 
     const std::string module_id;
 
@@ -44,31 +53,20 @@ public:
     {% endfor %}
     {% endif %}
 
-    {% if not errors %}
-    // This interface does not export any errors to subscribe to
-    {% else %}
-    // errors available for subscription
-    {% for error in errors %}
-    void subscribe_error_{{ error.namespace }}_{{ error.name }}(
-        const Everest::error::ErrorCallback& error_listener,
-        const Everest::error::ErrorCallback& error_cleared_listener
+    void subscribe_error(
+        const Everest::error::ErrorType& type,
+        const Everest::error::ErrorCallback& callback,
+        const Everest::error::ErrorCallback& clear_callback
     ) {
-        _adapter->subscribe_error(_req, "{{ error.namespace }}/{{ error.name }}", error_listener);
-        _adapter->subscribe_error_cleared(_req, "{{ error.namespace }}/{{ error.name }}", error_cleared_listener);
+        error_manager->subscribe_error(type, callback, clear_callback);
     }
-    {% if not loop.last %}
 
-    {% endif %}
-    {% endfor %}
     void subscribe_all_errors(
-        const Everest::error::ErrorCallback& error_listener,
-        const Everest::error::ErrorCallback& error_cleared_listener
+        const Everest::error::ErrorCallback& callback,
+        const Everest::error::ErrorCallback& clear_callback
     ) {
-        {% for error in errors %}
-        subscribe_error_{{ error.namespace }}_{{ error.name }}(error_listener, error_cleared_listener);
-        {% endfor %}
+        error_manager->subscribe_all_errors(callback, clear_callback);
     }
-    {% endif %}
 
     {% if not cmds %}
     // this interface does not export any commands to call
@@ -121,7 +119,10 @@ public:
     {% endfor %}
     {% endif %}
 
+    std::shared_ptr<Everest::error::ErrorStateMonitor> error_state_monitor;
+
 private:
+    std::shared_ptr<Everest::error::ErrorManagerReq> error_manager;
     Everest::ModuleAdapter* const _adapter;
     Requirement _req;
 };

--- a/ev-dev-tools/src/ev_cli/templates/ld-ev.cpp.j2
+++ b/ev-dev-tools/src/ev_cli/templates/ld-ev.cpp.j2
@@ -117,11 +117,10 @@ std::vector<Everest::cmd> everest_register(const json& connections) {
 
 {% if info.enable_global_errors %}
 void subscribe_global_all_errors(
-    const Everest::error::ErrorCallback& error_listener,
-    const Everest::error::ErrorCallback& error_cleared_listener
+    const Everest::error::ErrorCallback& callback,
+    const Everest::error::ErrorCallback& clear_callback
 ) {
-    adapter.subscribe_all_errors(error_listener);
-    adapter.subscribe_all_errors_cleared(error_cleared_listener);
+    adapter.subscribe_global_all_errors(callback, clear_callback);
 }
 {% endif %}
 } // namespace module

--- a/ev-dev-tools/src/ev_cli/templates/ld-ev.hpp.j2
+++ b/ev-dev-tools/src/ev_cli/templates/ld-ev.hpp.j2
@@ -24,8 +24,8 @@ std::vector<Everest::cmd> everest_register(const json& connections);
 
 {% if info.enable_global_errors %}
 void subscribe_global_all_errors(
-    const Everest::error::ErrorCallback& error_listener,
-    const Everest::error::ErrorCallback& error_cleared_listener
+    const Everest::error::ErrorCallback& callback,
+    const Everest::error::ErrorCallback& clear_callback
 );
 {% endif %}
 


### PR DESCRIPTION
## Changes
Implementation Base Template:
* Add error_manager
* Add error_state_monitor
* Add error_factory
* Update raise_error interface
* Update clear_error interface

Export Template
* Add error_manager
* Add error_state_monitor
* Update subscribe_error interface

ld-ev template
* Update subscribe_global_all_errors interface

## Requires
* Should be merged together with https://github.com/EVerest/everest-framework/pull/186