### PR TITLE
Add missing libcap dependency.

### DIFF
--- a/docker/everest-playground/.devcontainer.json
+++ b/docker/everest-playground/.devcontainer.json
@@ -7,12 +7,25 @@
     "MQTT_SERVER_ADDRESS": "mqtt-server",
     "MQTT_SERVER_PORT": "1883"
   },
-  "extensions": [
-    "ms-python.python",
-    "ms-vscode.cpptools",
-    "twxs.cmake",
-    "ms-vscode.cmake-tools"
-  ],
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "ms-vscode.cpptools",
+        "twxs.cmake",
+        "ms-vscode.cmake-tools"
+      ],
+      "settings": {
+        "terminal.integrated.profiles.linux": {
+          "bash": {
+            "path": "/bin/bash"
+          }
+        },
+        "terminal.integrated.defaultProfile.linux": "bash",
+        "python.pythonPath": "/usr/bin/python3"
+      }
+    }
+  },
   "postCreateCommand": "",
   "remoteUser": "docker",
   "runArgs": [
@@ -20,13 +33,5 @@
   ],
   "workspaceFolder": "/workspace/everest-cpp",
   "workspaceMount": "source=${localWorkspaceFolder}/../../,target=/workspace,type=bind",
-  "settings": {
-    "terminal.integrated.profiles.linux": {
-      "bash": {
-        "path": "/bin/bash"
-      }
-    },
-    "terminal.integrated.defaultProfile.linux": "bash",
-    "python.pythonPath": "/usr/bin/python3"
-  }
+
 }

--- a/docker/everest-playground/Dockerfile
+++ b/docker/everest-playground/Dockerfile
@@ -43,6 +43,7 @@ RUN apt-get update \
     libssl-dev \
     libcurl4-openssl-dev \
     pkg-config \
+    libcap-dev \
     libpcap-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/docker/everest-playground/Dockerfile
+++ b/docker/everest-playground/Dockerfile
@@ -34,8 +34,8 @@ RUN apt-get update \
     clang-tidy \
     cppcheck \
     libboost-all-dev \
-    maven \
-    openjdk-11-jdk \
+    # maven \
+    # openjdk-11-jdk \
     nodejs \
     npm \
     libsqlite3-dev \

--- a/docker/everest-playground/Dockerfile
+++ b/docker/everest-playground/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=debian:11
+ARG BASE_IMAGE=debian:bookworm
 FROM ${BASE_IMAGE}
 
 ARG BASE_IMAGE


### PR DESCRIPTION
Add missing `libcap`.
Also updates the `.devcontainer.json` to current format.

fixes #143 