### PR TITLE
fix: Python testing dependnecies

### DIFF
--- a/everest-testing/setup.cfg
+++ b/everest-testing/setup.cfg
@@ -19,11 +19,13 @@ install_requires =
     python-dateutil
     paho-mqtt ==1.6.1
     pyftpdlib
-    ocpp
+    ocpp ==0.26.0
     websockets
     pyOpenSSL
+    pyyaml
+    cryptography ==41.0.1
 
-package_dir = 
+package_dir =
     = src
 
 python_requires = >=3.8

--- a/everest-testing/src/everest/testing/core_utils/everest_core.py
+++ b/everest-testing/src/everest/testing/core_utils/everest_core.py
@@ -205,7 +205,7 @@ class EverestCore:
     def read_everest_log(self):
         while self.process.poll() == None:
             stderr_raw = self.process.stderr.readline()
-            stderr_formatted = stderr_raw.strip().decode()
+            stderr_formatted = stderr_raw.strip().decode(errors="ignore")
             logging.debug(f'  {stderr_formatted}')
 
         if self.process.returncode == 0:


### PR DESCRIPTION
Some packages used in everest-testing have newer versions that cause conflicts. The working version of the dependency is now explicitly listed