### PR TITLE
Add CMake to python packages ev-dev-tools and everest-testing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.14)
+
+project(everest-utils
+    VERSION 0.2.3
+    DESCRIPTION "A collection of utilities for the EVerest project"
+    LANGUAGES CXX C
+)
+
+find_package(everest-cmake 0.3 REQUIRED
+    PATHS ../everest-cmake
+)
+
+ev_setup_cmake_variables_python_wheel()
+
+add_subdirectory(ev-dev-tools)
+add_subdirectory(everest-testing)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.14)
 
 project(everest-utils
-    VERSION 0.2.3
+    VERSION 0.3.0
     DESCRIPTION "A collection of utilities for the EVerest project"
     LANGUAGES CXX C
 )

--- a/ev-dev-tools/CMakeLists.txt
+++ b/ev-dev-tools/CMakeLists.txt
@@ -1,0 +1,9 @@
+ev_create_pip_install_targets(
+    PACKAGE_NAME
+        "ev-dev-tools"
+)
+
+ev_create_python_wheel_targets(
+    PACKAGE_NAME
+        "ev-dev-tools"
+)

--- a/everest-testing/CMakeLists.txt
+++ b/everest-testing/CMakeLists.txt
@@ -1,0 +1,9 @@
+ev_create_pip_install_targets(
+    PACKAGE_NAME
+        "everest-testing"
+)
+
+ev_create_python_wheel_targets(
+    PACKAGE_NAME
+        "everest-testing"
+)


### PR DESCRIPTION
## Changes

Add `CMakeLists.txt` files to allow pip install targets and weel build targets for  `ev-dev-tools` and `everest-testing`

## Requires
* https://github.com/EVerest/everest-cmake/pull/4

## TODO before Merging

- [x] Bump version in CMake file -> `v0.3.0`

## TODO after Merging

- [ ] Release/Tag new version -> `v0.3.0`