### PR TITLE
ev_cli: attribute parameter of _gather_cmds with [[maybe_unused]]

### DIFF
--- a/ev-dev-tools/src/ev_cli/templates/interface-Base.hpp.j2
+++ b/ev-dev-tools/src/ev_cli/templates/interface-Base.hpp.j2
@@ -107,7 +107,7 @@ private:
     std::shared_ptr<Everest::error::ErrorManagerImpl> error_manager;
 
     // helper function for getting all commands
-    void _gather_cmds(std::vector<Everest::cmd>& cmds) override {
+    void _gather_cmds([[maybe_unused]] std::vector<Everest::cmd>& cmds) override {
     {% if not cmds %}
         // this interface does not offer any commands
     {% else %}


### PR DESCRIPTION
Without this attribute, interfaces without commands generate a lot of warnings since the parameter is not used inside the function.