### PR TITLE
feature: support `__gcov_dump` on signals

### DIFF
--- a/ev-dev-tools/src/ev_cli/__init__.py
+++ b/ev-dev-tools/src/ev_cli/__init__.py
@@ -1,2 +1,2 @@
 """EVerest command line utility."""
-__version__ = '0.4.4'
+__version__ = '0.4.5'

--- a/ev-dev-tools/src/ev_cli/templates/ld-ev.cpp.j2
+++ b/ev-dev-tools/src/ev_cli/templates/ld-ev.cpp.j2
@@ -4,6 +4,10 @@
 
 #include "{{ info.ld_ev_header }}"
 
+#ifdef EVEREST_COVERAGE_ENABLED
+#include <everest/staging/helpers/coverage.hpp>
+#endif
+
 #include "{{ info.module_header }}"
 {% for impl in provides %}
 #include "{{ impl.class_header }}"
@@ -150,6 +154,10 @@ std::vector<Everest::cmd> everest_register(const RequirementInitialization& requ
 } // namespace module
 
 int main(int argc, char* argv[]) {
+#ifdef EVEREST_COVERAGE_ENABLED
+    everest::helpers::install_signal_handlers_for_gcov();
+#endif
+
     auto module_loader = Everest::ModuleLoader(argc, argv, Everest::ModuleCallbacks(
         module::register_module_adapter, module::everest_register,
         module::LdEverest::init, module::LdEverest::ready),


### PR DESCRIPTION
- the auto-generated loader (`ld-ev`) now calls a helper function, if `EVEREST_COVERAGE_ENABLED` is enabled
- this helper function, which is implemented in everest-core helper library, registers signal handlers, that will call `__gcov_dump` and terminate