### PR TITLE
ev-cli: fix: install missing licenses directory

### DIFF
--- a/ev-dev-tools/setup.cfg
+++ b/ev-dev-tools/setup.cfg
@@ -30,4 +30,5 @@ console_scripts =
 [options.package_data]
 ev_cli =
     templates/*.j2
+    licenses/**
 

--- a/ev-dev-tools/src/ev_cli/__init__.py
+++ b/ev-dev-tools/src/ev_cli/__init__.py
@@ -1,2 +1,2 @@
 """EVerest command line utility."""
-__version__ = '0.5.0'
+__version__ = '0.5.1'

--- a/ev-dev-tools/src/ev_cli/licenses/spdx.org/licenses/Apache-2.0
+++ b/ev-dev-tools/src/ev_cli/licenses/spdx.org/licenses/Apache-2.0
@@ -1,0 +1,2 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest

--- a/ev-dev-tools/src/ev_cli/licenses/spdx.org/licenses/Apache-2.0.html
+++ b/ev-dev-tools/src/ev_cli/licenses/spdx.org/licenses/Apache-2.0.html
@@ -1,0 +1,2 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest


### PR DESCRIPTION
Otherwise a globally installed ev-dev-tools/ev-cli will not be able to find this licenses directory

Add additional aliases for Apache-2.0 license used in EVerest modules