### PR TITLE
Generated types: introduce comparison operators

### DIFF
--- a/ev-dev-tools/src/ev_cli/__init__.py
+++ b/ev-dev-tools/src/ev_cli/__init__.py
@@ -1,2 +1,2 @@
 """EVerest command line utility."""
-__version__ = '0.5.1'
+__version__ = '0.5.2'

--- a/ev-dev-tools/src/ev_cli/templates/types.hpp.j2
+++ b/ev-dev-tools/src/ev_cli/templates/types.hpp.j2
@@ -9,6 +9,7 @@
 #include <ostream>
 #include <stdexcept>
 #include <string>
+#include <tuple>
 #include <vector>
 
 #include <nlohmann/json.hpp>
@@ -196,6 +197,25 @@ struct {{ parsed_type.name }} {
         }
             {% endif %}
         {% endfor %}
+    }
+
+    /// \brief Compares objects of type {{ parsed_type.name }} for equality
+    bool operator==(const {{ parsed_type.name }}& k) const {
+        {%- for var, tuple in [('this->', 'lhs'), ('k.', 'rhs')] +%}
+        const auto& {{ tuple }}_tuple = std::tie(
+        {%- for property in parsed_type.properties +%}
+            {{ var }}{{ property.name }}
+            {%- if not loop.last %},
+            {%- endif %}
+        {%- endfor +%}
+        );
+        {%- endfor +%}
+        return lhs_tuple == rhs_tuple;
+    }
+
+    /// \brief Compares objects of type {{ parsed_type.name }} for inequality
+    bool operator!=(const {{ parsed_type.name }}& k) const {
+        return not (*this == k);
     }
 
     /// \brief Writes the string representation of the given {{ parsed_type.name }} \p k to the given output stream \p os

--- a/ev-dev-tools/src/ev_cli/templates/types.hpp.j2
+++ b/ev-dev-tools/src/ev_cli/templates/types.hpp.j2
@@ -3,7 +3,7 @@
 #ifndef {{ info.hpp_guard }}
 #define {{ info.hpp_guard }}
 
-{{ print_template_info('4') }}
+{{ print_template_info('5') }}
 
 #include <optional>
 #include <ostream>

--- a/ev-dev-tools/src/ev_cli/templates/types.hpp.j2
+++ b/ev-dev-tools/src/ev_cli/templates/types.hpp.j2
@@ -200,8 +200,8 @@ struct {{ parsed_type.name }} {
     }
 
     /// \brief Compares objects of type {{ parsed_type.name }} for equality
-    bool operator==(const {{ parsed_type.name }}& k) const {
-        {%- for var, tuple in [('this->', 'lhs'), ('k.', 'rhs')] +%}
+    friend constexpr bool operator==(const {{ parsed_type.name }}& k, const {{ parsed_type.name }}& l) {
+        {%- for var, tuple in [('k.', 'lhs'), ('l.', 'rhs')] +%}
         const auto& {{ tuple }}_tuple = std::tie(
         {%- for property in parsed_type.properties +%}
             {{ var }}{{ property.name }}
@@ -214,8 +214,8 @@ struct {{ parsed_type.name }} {
     }
 
     /// \brief Compares objects of type {{ parsed_type.name }} for inequality
-    bool operator!=(const {{ parsed_type.name }}& k) const {
-        return not (*this == k);
+    friend constexpr bool operator!=(const {{ parsed_type.name }}& k, const {{ parsed_type.name }}& l) {
+        return not operator==(k, l);
     }
 
     /// \brief Writes the string representation of the given {{ parsed_type.name }} \p k to the given output stream \p os

--- a/ev-dev-tools/src/ev_cli/templates/types.hpp.j2
+++ b/ev-dev-tools/src/ev_cli/templates/types.hpp.j2
@@ -54,7 +54,7 @@ inline std::string {{ enum.enum_type | snake_case }}_to_string({{ enum.enum_type
 /// \returns a {{ enum.enum_type }} from a string representation
 inline {{ enum.enum_type }} string_to_{{ enum.enum_type | snake_case }}(const std::string& s) {
     {% for e in enum.enum %}
-    if(s == "{{e}}") {
+    if (s == "{{e}}") {
         return {{ enum.enum_type }}::{{ e }};
     }
     {% endfor %}
@@ -87,54 +87,52 @@ namespace {{ namespace }} {
 {% for parsed_type in types %}
 {% if parsed_type.properties|length > 0 %}
 struct {{ parsed_type.name }} {
-    {% for property in parsed_type.properties %}
-        {# Constraints will be checked by the framework #}
-        {{ 'std::optional<' if not property.required -}}
-        {{ property.type -}}
-        {{ '>' if not property.required -}}
-        {{ ' ' + property.name + ';' }} ///< {{ property.info.description }}
-    {% endfor %}
+{% for property in parsed_type.properties %}
+    {# Constraints will be checked by the framework #}
+    {{ 'std::optional<' if not property.required -}}
+    {{ property.type -}}
+    {{ '>' if not property.required -}}
+    {{ ' ' + property.name + ';' }} ///< {{ property.info.description }}
+{% endfor %}
 
     /// \brief Conversion from a given {{ parsed_type.name }} \p k to a given json object \p j
     friend void to_json(json& j, const {{ parsed_type.name }}& k) {
         // the required parts of the type
         {% if parsed_type.properties|selectattr('required')|list|length %}
-                j = json{
+        j = json{
         {%- endif %}
         {%- for property in parsed_type.properties %}
-        {%- if property.required %}{"{{property.name}}",
-            {%- if property.enum %}
-                {{ enum_to_string(property.type) }}(k.{{ property.name }})
+        {%- if property.required +%}
+            {"{{property.name}}",
+            {%- if property.enum %} {{ enum_to_string(property.type) }}(k.{{ property.name }})
             {%- else %}
-                {%- if property.type == 'DateTime' %}
-        k.{{property.name}}.to_rfc3339()
-                {%- else %}
-        k.{{property.name}}
+                {%- if property.type == 'DateTime' %} k.{{property.name}}.to_rfc3339()
+                {%- else %} k.{{property.name}}
                 {%- endif %}
             {%- endif %}},
         {%- endif %}
         {%- endfor %}
         {% if not parsed_type.properties|selectattr('required')|list|length %}
-                j = json ({});
-        {%- else %}
+        j = json ({});
+        {%- else +%}
         };
         {%- endif %}
 
-                // the optional parts of the type
+        // the optional parts of the type
         {% for property in parsed_type.properties %}
         {% if not property.required %}
-                if (k.{{property.name}}) {
+        if (k.{{property.name}}) {
                     {% if property.type.startswith('std::vector<') %}
                     {%- if parsed_type.properties|selectattr('required')|list|length %}
-        j["{{property.name}}"] = json::array();
+            j["{{property.name}}"] = json::array();
                     {%- else %}
         {#only optional keys in json#}
         {#TODO: add key to json when there are no required keys but multiple optional keys#}
-        if (j.size() == 0) {
-                        j = json{{'{{"'+property.name+'", json::array()}};'}}
-                    } else {
-                        j["{{property.name}}"] = json::array();
-                    }
+            if (j.size() == 0) {
+                j = json{{'{{"'+property.name+'", json::array()}};'}}
+            } else {
+                j["{{property.name}}"] = json::array();
+            }
         {% endif %}
                     for (auto val : k.{{property.name}}.value()) {
                         j["{{property.name}}"].push_back(val);
@@ -144,14 +142,14 @@ struct {{ parsed_type.name }} {
         j["{{property.name}}"] = {{ enum_to_string(property.type) }}(k.{{ property.name }}.value());
             {%- else %}
                 {%- if property.type == 'DateTime' %}
-        j["{{property.name}}"] = k.{{property.name}}.value().to_rfc3339();
+            j["{{property.name}}"] = k.{{property.name}}.value().to_rfc3339();
                 {%- else %}
-        j["{{property.name}}"] = k.{{property.name}}.value();
+            j["{{property.name}}"] = k.{{property.name}}.value();
                 {%- endif %}
             {%- endif %}
         {% endif %}
 
-                }
+        }
         {% endif %}
         {% endfor %}
     }
@@ -160,45 +158,42 @@ struct {{ parsed_type.name }} {
     friend void from_json(const json& j, {{ parsed_type.name }}& k) {
         // the required parts of the type
         {% for property in parsed_type.properties %}
-            {% if property.required %}
-                {% if property.type.startswith('std::vector<') %}
-                    for (auto val : j.at("{{property.name}}")) {
-                        k.{{property.name}}.push_back(val);
-                    }
-                {% else %}
-                    k.{{property.name}} =
-                    {%- if property.enum %}
-                        {{ string_to_enum(property.type) }}(j.at("{{property.name}}"))
-                    {%- else %}
-                        {%- if property.type == 'DateTime' %}
-                            DateTime(std::string(j.at("{{property.name}}")));
-                        {%- else %}
-                            j.at("{{property.name}}")
-                        {%- endif %}
-                    {%- endif %};
-                {% endif %}
-            {% endif %}
+        {% if property.required %}
+        {% if property.type.startswith('std::vector<') %}
+        for (auto val : j.at("{{property.name}}")) {
+            k.{{property.name}}.push_back(val);
+        }
+        {% else %}
+        k.{{property.name}} =
+            {%- if property.enum %} {{ string_to_enum(property.type) }}(j.at("{{property.name}}"))
+            {%- else %}
+                {%- if property.type == 'DateTime' %} DateTime(std::string(j.at("{{property.name}}")));
+                {%- else %} j.at("{{property.name}}")
+                {%- endif %}
+            {%- endif %};
+        {% endif %}
+        {% endif %}
         {%- endfor %}
 
         // the optional parts of the type
         {% for property in parsed_type.properties %}
             {% if not property.required %}
-            if (j.contains("{{property.name}}")) {
+        if (j.contains("{{property.name}}")) {
                 {% if property.type.startswith('std::vector<') %}
-                    json arr = j.at("{{property.name}}");
-                    {{property.type}} vec;
-                    for (auto val : arr) {
-                        vec.push_back(val);
-                    }
-                    k.{{property.name}}.emplace(vec);
+            json arr = j.at("{{property.name}}");
+            {{property.type}} vec;
+            for (auto val : arr) {
+                vec.push_back(val);
+            }
+            k.{{property.name}}.emplace(vec);
                 {% else %}
                     {%- if property.enum %}
-                    k.{{property.name}}.emplace({{ string_to_enum(property.type) }}(j.at("{{property.name}}")));
+            k.{{property.name}}.emplace({{ string_to_enum(property.type) }}(j.at("{{property.name}}")));
                     {%- else %}
-                    k.{{property.name}}.emplace(j.at("{{property.name}}"));
+            k.{{property.name}}.emplace(j.at("{{property.name}}"));
                     {% endif %}
                 {% endif %}
-            }
+        }
             {% endif %}
         {% endfor %}
     }


### PR DESCRIPTION
Add the comparison operator `==` and the explicit opposite `!=` to all generated complex types.

Also improve the formatting of the generated types' code regarding indentation, whitespace and line lengths, for "readability". (I am aware that this code isn't often read. We often look things up from the reference within the code editor though.) Other code, such as the interface implementations, still has wild formatting.

The YAML types generation is being used by the coming JSON RPC API module **RpcApi** ([WIP branch](https://github.com/EVerest/everest-core/tree/feature/json-rpc-api)), because of its ease of creating complex C++ object/struct trees with optional members. A comparison operator is a massive relief for checking for changes e,g, after applying setters.

---

This is an example of the new operators. `std::tie` uses only references, making this operation itself complete copy-less:
```c++
    /// \brief Compares objects of type ConnectorInfoObj for equality
    bool operator==(const ConnectorInfoObj& k) const {
        const auto& lhs_tuple = std::tie(
            this->id,
            this->type,
            this->description
        );
        const auto& rhs_tuple = std::tie(
            k.id,
            k.type,
            k.description
        );
        return lhs_tuple == rhs_tuple;
    }

    /// \brief Compares objects of type ConnectorInfoObj for inequality
    bool operator!=(const ConnectorInfoObj& k) const {
        return not (*this == k);
    }
```

This diff is an example of the change in formatting:
```diff
 struct ConnectorInfoObj {
-        int32_t id; ///< Unique identifier
-        types::json_rpc_api::ConnectorTypeEnum type; ///< Connector type
-        std::optional<std::string> description; ///< Description
+    int32_t id; ///< Unique identifier
+    types::json_rpc_api::ConnectorTypeEnum type; ///< Connector type
+    std::optional<std::string> description; ///< Description
 
     /// \brief Conversion from a given ConnectorInfoObj \p k to a given json object \p j
     friend void to_json(json& j, const ConnectorInfoObj& k) {
         // the required parts of the type
-                j = json{{"id",        k.id},{"type",                types::json_rpc_api::connector_type_enum_to_string(k.type)},        };
-                // the optional parts of the type
-                if (k.description) {
-        j["description"] = k.description.value();
-                }
+        j = json{
+            {"id", k.id},
+            {"type", types::json_rpc_api::connector_type_enum_to_string(k.type)},
+        };
+        // the optional parts of the type
+        if (k.description) {
+            j["description"] = k.description.value();
+        }
     }
 
     /// \brief Conversion from a given json object \p j to a given ConnectorInfoObj \p k
     friend void from_json(const json& j, ConnectorInfoObj& k) {
         // the required parts of the type
-                    k.id =                            j.at("id");
-                    k.type =                        types::json_rpc_api::string_to_connector_type_enum(j.at("type"));
+        k.id = j.at("id");
+        k.type = types::json_rpc_api::string_to_connector_type_enum(j.at("type"));
 
         // the optional parts of the type
-            if (j.contains("description")) {
-                    k.description.emplace(j.at("description"));
-            }
+        if (j.contains("description")) {
+            k.description.emplace(j.at("description"));
+        }
+    }
```