### PR TITLE
Add EverestDeviceModelDatabasePath OCPP201 param to everest-testing

### DIFF
--- a/everest-testing/src/everest/testing/core_utils/_configuration/everest_configuration_strategies/ocpp_module_configuration_strategy.py
+++ b/everest-testing/src/everest/testing/core_utils/_configuration/everest_configuration_strategies/ocpp_module_configuration_strategy.py
@@ -22,7 +22,7 @@ class OCPPModulePaths201(OCPPModuleConfigurationBase):
     DeviceModelConfigPath: str
     CoreDatabasePath: str
     DeviceModelDatabasePath: str
-
+    EverestDeviceModelDatabasePath: str
 
 class OCPPModuleConfigurationStrategy(EverestConfigAdjustmentStrategy):
     """ Adjusts the Everest configuration by manipulating the OCPP module configuration to use proper (temporary test) paths.

--- a/everest-testing/src/everest/testing/core_utils/_configuration/everest_environment_setup.py
+++ b/everest-testing/src/everest/testing/core_utils/_configuration/everest_environment_setup.py
@@ -188,6 +188,7 @@ class EverestTestEnvironmentSetup:
                 MessageLogPath=str(temporary_paths.ocpp_message_log_directory),
                 CoreDatabasePath=str(temporary_paths.ocpp_database_dir),
                 DeviceModelDatabasePath=str(temporary_paths.ocpp_database_dir / "device_model_storage.db"),
+                EverestDeviceModelDatabasePath=str(temporary_paths.ocpp_database_dir / "everest_device_model_storage.db")
             )
         else:
             raise ValueError(f"unknown  ocpp version {self._ocpp_config.ocpp_version}")


### PR DESCRIPTION
Add new OCPP201 module parameter: EverestDeviceModelDatabasePath to everest-testing, so that this is written to the temporary test case directory