### PR TITLE
Remove staging from jinja

### DIFF
--- a/ev-dev-tools/src/ev_cli/templates/ld-ev.cpp.j2
+++ b/ev-dev-tools/src/ev_cli/templates/ld-ev.cpp.j2
@@ -5,7 +5,7 @@
 #include "{{ info.ld_ev_header }}"
 
 #ifdef EVEREST_COVERAGE_ENABLED
-#include <everest/staging/helpers/coverage.hpp>
+#include <everest/helpers/coverage.hpp>
 #endif
 
 #include "{{ info.module_header }}"


### PR DESCRIPTION
Removed staging namespace from import because it has been removed in everest-core